### PR TITLE
Fix AMA bot: read-only Q&A agent + final-message-only extraction

### DIFF
--- a/.github/workflows/ama-answer.yml
+++ b/.github/workflows/ama-answer.yml
@@ -9,8 +9,9 @@ name: "🤖 AMA — Answer the AI"
 # - A maintainer can force a re-run on any older issue by adding the `question` label.
 # - All untrusted text (issue body, question, model answer) is passed via `env:`
 #   and referenced as quoted variables — never inlined into a run:/script: body.
-# - opencode runs sandboxed (bash/write/edit/webfetch off — see ama-agent.md);
-#   the token is contents:read only and not persisted, so nothing can edit code.
+# - opencode runs sandboxed as a read-only Q&A agent (bash/write/edit/webfetch
+#   off — enforced in .opencode/agent/ama-agent.md); the token is contents:read
+#   only and not persisted, so nothing can edit code.
 
 on:
   issues:
@@ -159,10 +160,20 @@ jobs:
           --pure \
           2>/dev/null || true)
 
-        ANSWER=$(printf '%s' "$OUTPUT" | jq -s '
-          [.[] | select(.type == "text" and .part.type == "text") | .part.text]
-          | join("\n\n")
-        ' --raw-output 2>/dev/null || true)
+        # Post ONLY the final assistant message, not the whole run. The old
+        # code joined every text part, so any intermediate reasoning/narration
+        # ("Let me look at…", plans, "Build successful") leaked into the comment
+        # and read as if a fix had been implemented. Here we find the messageID
+        # of the last text part (stream order is preserved by `-s`), then join
+        # just that message's text parts. If parts carry no messageID, every
+        # match has a null id and this degrades to "join all" — still safe once
+        # the ama-agent persona stops emitting task narration.
+        ANSWER=$(printf '%s' "$OUTPUT" | jq -s -r '
+          [ .[] | select(.type == "text" and .part.type == "text") ] as $t
+          | ( $t | last | .part.messageID ) as $mid
+          | [ $t[] | select(.part.messageID == $mid) | .part.text ]
+          | join("")
+        ' 2>/dev/null || true)
 
         if [ -z "$ANSWER" ] || [ "$ANSWER" = "null" ]; then
           ANSWER="⚠️ No answer generated. The AI may have timed out or hit an error."

--- a/.opencode/agent/ama-agent.md
+++ b/.opencode/agent/ama-agent.md
@@ -1,0 +1,68 @@
+---
+description: >-
+  Read-only Q&A responder for Bannerlator GitHub issues. Diagnoses and explains
+  grounded in the codebase; never edits, builds, commits, or pushes, and never
+  claims to have done so.
+mode: primary
+temperature: 0.2
+# NOTE: the model is set on the CLI (`--model opencode/big-pickle` in
+# ama-answer.yml) and that takes precedence over anything set here.
+tools:
+  # Read-only grounding — the bot may inspect the repo to cite real evidence.
+  read: true
+  grep: true
+  glob: true
+  list: true
+  # Everything that mutates state, runs commands, reaches the network, or turns
+  # this into a "task agent" is OFF. This is what the ama-answer.yml security
+  # comment promises — enforce it here.
+  write: false
+  edit: false
+  patch: false
+  bash: false
+  webfetch: false
+  todowrite: false
+  todoread: false
+---
+
+You are **Bannerlator AI**, answering a single GitHub issue on the Bannerlator
+repository (a personal, community-driven continuation of Winlator Star Bionic
+for running Windows games on Android via Wine + Box64/86).
+
+Your job is to **answer the user's question or triage their bug report** — and
+nothing else.
+
+## Hard rules
+
+- You have **read-only** access. You **cannot** modify code, add files, run
+  builds, run commands, commit, or push — and none of that would reach the repo
+  anyway (the CI token is `contents: read`). So **never** say or imply that you
+  did any of it. Banned phrasing includes: "Let me implement…", "Changes made:",
+  "Build successful", "Now pushing…", "I've added/fixed/created…", "Done."
+- Describe fixes as **proposals**, not completed work: "A fix would be to …",
+  "The change that would address this is …", "You could try …". Never present a
+  fix as already applied.
+- Do **not** narrate a task or emit a plan/progress log. No "Let me look at…",
+  no Done/In-Progress/Next-Steps/Blocked sections. Produce **one** final,
+  self-contained answer — the reader sees only your last message.
+- Ground claims in the actual codebase. When you point at a cause, cite
+  `path/File.ext:line` so it's checkable. If you did not verify something, say
+  so rather than asserting it.
+- Be honest about limits. If you can't reproduce it, don't know, or it depends
+  on hardware you can't see, say that plainly. A calibrated "I'm not sure, but
+  the likely cause is…" is better than a confident guess.
+- Do **not** append the project "personal build / no support / GPL-3.0" notice —
+  the workflow adds it automatically after your answer.
+
+## Answer shape
+
+Keep it concise and in GitHub-flavored Markdown. A good answer usually:
+
+1. States the likely cause in a sentence or two.
+2. Backs it with specific `file:line` evidence when you inspected the code.
+3. Gives the user something actionable right now (a setting, a workaround), and
+   — if relevant — describes what a code fix *would* look like, framed as a
+   suggestion, not a delivered change.
+
+If the report is too vague to act on (no device, GPU, driver, logs, or repro
+steps), ask for the specific missing details instead of guessing.


### PR DESCRIPTION
## Problem

The AMA bot (`.github/workflows/ama-answer.yml`) has been posting answers that read like a coding worklog — e.g. on #59 it wrote "Let me implement the solution", a full Done/In-Progress/Next-Steps plan, "Build successful across all 3 flavors", and "Now pushing upstream" — **implying a fix had shipped**. Nothing actually reaches the repo (the token is `contents: read`, `persist-credentials: false`), so those claims are misleading.

### Root causes
1. **The agent persona didn't exist.** The workflow calls `opencode run --agent ama-agent`, but no `ama-agent` definition was committed anywhere. opencode fell back to its **default coding agent**, whose job is to plan → edit → build → commit → push. The security comment claimed *"bash/write/edit/webfetch off — see ama-agent.md"*, but that file was missing, so those tools were effectively **on**.
2. **The extractor dumped the whole run.** The jq step joined **every** text part of the stream, so all intermediate reasoning/narration leaked into the posted comment instead of just the final answer.

## Fix

**1. Add `.opencode/agent/ama-agent.md`** — a read-only Q&A persona:
- Tools disabled: `bash`, `write`, `edit`, `patch`, `webfetch`, `todowrite`, `todoread`. Enabled: `read`, `grep`, `glob`, `list`. This actually **enforces** the sandbox the security comment already promised.
- Instructs the model to: answer once (no plans/progress logs), ground claims in `file:line` evidence, frame fixes as **proposals** not delivered work, be honest about uncertainty, and never claim to have edited/built/committed/pushed.

**2. Post only the final assistant message** — the new jq keys off the `messageID` of the last text part and joins just that message. Degrades safely to "join all" if parts carry no id.

## Validation
- Workflow YAML parses clean (`yaml.safe_load`).
- Agent frontmatter parses; tool flags verified (disabled: bash/edit/patch/todo*/webfetch/write; enabled: read/grep/glob/list).
- jq logic unit-tested against a simulated multi-message opencode stream: correctly returns only the final message, drops earlier narration; handles the no-`messageID` and empty-stream cases.

Not yet proven live — the real test is the next opened issue (or forcing a re-run by adding the `question` label to an existing one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)