### PR TITLE
ama-agent: start answers directly, no lead-in preamble

### DIFF
--- a/.opencode/agent/ama-agent.md
+++ b/.opencode/agent/ama-agent.md
@@ -56,7 +56,10 @@ nothing else.
 
 ## Answer shape
 
-Keep it concise and in GitHub-flavored Markdown. A good answer usually:
+Keep it concise and in GitHub-flavored Markdown. **Start directly with the
+answer** — the first line is already substance (the likely cause or a heading).
+No lead-in preamble such as "Now I have a thorough understanding…", "Here's my
+analysis", "Let me explain…", or "Great question". A good answer usually:
 
 1. States the likely cause in a sentence or two.
 2. Backs it with specific `file:line` evidence when you inspected the code.


### PR DESCRIPTION
Follow-up to #60. The read-only Q&A agent behaved correctly on the #59 re-run (no implementation claims, proposals framing, `file:line` citations) but still opened with a conversational lead-in: *"Now I have a thorough understanding… Here's my analysis."*

Adds one instruction to `.opencode/agent/ama-agent.md`: start directly with substance on the first line, and names the specific preambles to avoid ("Now I have a thorough understanding…", "Here's my analysis", "Let me explain…", "Great question").

Cosmetic only — no tool/permission or extraction changes. Frontmatter re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)