### PR TITLE
Frame-gen present-path fixes, Xiaomi HUD/frame-gen fixes, and small UX improvements

### DIFF
--- a/.github/workflows/build-bionic-fg.yml
+++ b/.github/workflows/build-bionic-fg.yml
@@ -41,11 +41,31 @@ jobs:
           # (xXJSONDeruloXx/bionic-fg). It covers:
           #   1. manifest: add spec-required `disable_environment` (else the
           #      glibc Vulkan loader skips the implicit layer at parse time);
-          #   2. present path: bound the cross-context fence waits (UINT64_MAX ->
-          #      250ms) so a wrapper-ICD semaphore mismatch degrades to a real
-          #      present + disables framegen instead of hanging (ANR/SIGQUIT);
-          #   3. drop two instance exts wrongly listed as device exts.
-          # All verified on-device 2026-06-19; see BIONIC_FG_INTEGRATION_REPORT.md §2.
+          #   2. single-device mode: FramegenContext adopts the app's own
+          #      VkDevice instead of creating a standalone second one (fixes a
+          #      cross-device fence deadlock/ANR on wrapper-ICD stacks);
+          #   3. present path: bound the copy/generated-frame fence waits
+          #      (UINT64_MAX -> a fixed/derived timeout) so a stuck wait
+          #      degrades to a real present + disables framegen after
+          #      kMaxFenceTimeouts consecutive misses, instead of hanging;
+          #   4. present path: replace the post-dispatch vkQueueWaitIdle() with
+          #      FramegenContext::waitLastDispatch(), a bounded wait on just the
+          #      framegen compute submission's own fence. In single-device mode
+          #      the old waitIdle() drained the WHOLE shared queue every
+          #      present — on GPUs with one universal queue family (most mobile
+          #      Adreno/Turnip parts) that's the same queue the game itself
+          #      renders on, so every present serialized on the game's own
+          #      in-flight work too. This was the leading cause of a reported
+          #      ~50% FPS drop + jitter under bionic-fg vs. lsfg-vk in a heavy
+          #      DXVK title (Bioshock 2, tracked separately);
+          #   5. drop two instance exts wrongly listed as device exts;
+          #   6. dispatch-routed vkGetPhysicalDeviceMemoryProperties (avoids a
+          #      crash calling the global symbol from inside a layer with a
+          #      chain-level physical-device handle).
+          # (1)-(3), (5)-(6) verified on-device 2026-06-19; see
+          # BIONIC_FG_INTEGRATION_REPORT.md §2 / BIONIC_FG_UPSTREAM_REPORT.md.
+          # (4) is local-build-verified only as of this comment — still needs
+          # the on-device FPS/jitter re-test described in the fix's plan.
           git -C app/src/main/cpp/bionic-fg apply --verbose \
             "${GITHUB_WORKSPACE}/patches/bionic-fg-bannerlator-fixes.patch"
 

--- a/.github/workflows/build-bionic-fg.yml
+++ b/.github/workflows/build-bionic-fg.yml
@@ -61,11 +61,20 @@ jobs:
           #   5. drop two instance exts wrongly listed as device exts;
           #   6. dispatch-routed vkGetPhysicalDeviceMemoryProperties (avoids a
           #      crash calling the global symbol from inside a layer with a
-          #      chain-level physical-device handle).
-          # (1)-(3), (5)-(6) verified on-device 2026-06-19; see
+          #      chain-level physical-device handle);
+          #   7. generated-frame image acquire blocks for the next FIFO slot
+          #      (UINT64_MAX) instead of a non-blocking best-effort grab
+          #      (timeout=0) — mirrors lsfg-vk's Android pacing, avoids bursty
+          #      present-or-skip behavior under contention. Ported from
+          #      upstream's own (unmerged) fix, commit 86f80b8 on
+          #      origin/feat/future-refresh-pacing — cherry-picked alone; that
+          #      branch's larger async present-scheduler commits were NOT
+          #      taken (predate single-device-mode, would need a real merge).
+          # (1)-(3), (5)-(7) verified on-device 2026-06-19; see
           # BIONIC_FG_INTEGRATION_REPORT.md §2 / BIONIC_FG_UPSTREAM_REPORT.md.
-          # (4) is local-build-verified only as of this comment — still needs
-          # the on-device FPS/jitter re-test described in the fix's plan.
+          # (4) and (7) are local-build-verified only as of this comment —
+          # still need the on-device FPS/jitter re-test described in the fix's
+          # plan.
           git -C app/src/main/cpp/bionic-fg apply --verbose \
             "${GITHUB_WORKSPACE}/patches/bionic-fg-bannerlator-fixes.patch"
 

--- a/app/src/main/java/com/winlator/star/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/star/XServerDisplayActivity.java
@@ -587,6 +587,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 writeLsfgConfig(mult >= 2 ? mult : 1, flow, dll.getAbsolutePath());
                 if (fgOn) container.setFrameGenMultiplier(mult);
                 container.setFrameGenFlowScale(flow);
+                container.setFrameGenSessionOn(fgOn && mult >= 2); // resume this on/off next launch
                 container.saveData();
                 // lsfg multiplier may have crossed the >=2 threshold -> re-evaluate the limiter
                 // guard (lsfgGovernsFps) so the cap steps aside / resumes without extra user action.
@@ -598,6 +599,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
             writeBionicFgConfig(mult, flow, false, 0);
             if (fgOn) container.setFrameGenMultiplier(mult);
             container.setFrameGenFlowScale(flow);
+            container.setFrameGenSessionOn(fgOn && mult >= 2); // resume this on/off next launch
             container.saveData();
         };
         // Standalone FPS limiter: paces the X11 Present extension (delays IdleNotify) so the GAME
@@ -801,10 +803,12 @@ public class XServerDisplayActivity extends AppCompatActivity {
         boolean bionicFgActive = fgEnabled || lsfgOn;
         XServerDrawerState.INSTANCE.setBionicFgActive(bionicFgActive);
         XServerDrawerState.INSTANCE.setFrameGenEnabled(fgEnabled || lsfgOn);
-        // Frame gen ALWAYS starts OFF in-game (multiplier 0) regardless of the container setting.
-        // The layer is still loaded at launch (below), so the user can opt in per session from the
-        // FG drawer (live hot-reload). The persisted container multiplier is left untouched.
-        XServerDrawerState.INSTANCE.setFrameGenMultiplier(0);
+        // Restore the in-game frame-gen enable across sessions: if the user left FG multiplying,
+        // resume at the persisted multiplier; else start Off. Gated on bionicFgActive so the
+        // Edit-screen engine dropdown stays master — when no engine is selected the layer never
+        // loads and the persisted on-state is ignored (drawer shows the "enable it" placeholder).
+        XServerDrawerState.INSTANCE.setFrameGenMultiplier(
+                bionicFgActive ? resolvedFrameGenSessionMultiplier() : 0);
         XServerDrawerState.INSTANCE.setFrameGenFlowScale(container.getFrameGenFlowScale());
         XServerDrawerState.INSTANCE.setFrameGenEngine(fgEngine);
         XServerDrawerState.INSTANCE.setFpsLimiterEnabled(fpsLimOn);
@@ -2016,10 +2020,11 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 // Wine /proc/self/exe is the loader, so the real exe name is unusable).
                 File losslessDll = new File(getFilesDir(), "lsfg-vk/Lossless.dll");
                 if (losslessDll.isFile()) {
-                    // Start in passthrough (multiplier 1 = frame gen off). ENABLE_LSFG still loads the
-                    // layer, so the FG drawer can enable it live in-session (the conf.toml mtime watch
-                    // re-applies the user's multiplier without a relaunch). Container value untouched.
-                    writeLsfgConfig(1, container.getFrameGenFlowScale(), losslessDll.getAbsolutePath());
+                    // Resume the persisted in-game multiplier (>=2 -> multiplying) or start in
+                    // passthrough (1 = off) when FG was left Off. ENABLE_LSFG loads the layer either
+                    // way, so the FG drawer can still retune live (conf.toml mtime watch re-applies).
+                    int fgMult = resolvedFrameGenSessionMultiplier();
+                    writeLsfgConfig(fgMult >= 2 ? fgMult : 1, container.getFrameGenFlowScale(), losslessDll.getAbsolutePath());
                     File lsfgConf = new File(imageFs.home_path, ".config/lsfg-vk/conf.toml");
                     envVars.put("ENABLE_LSFG", "1");
                     envVars.put("LSFG_CONFIG", lsfgConf.getAbsolutePath());
@@ -2034,8 +2039,10 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 boolean fgOn = resolvedFrameGenEngine().equals("bionic");
                 if (fgOn) {
                     envVars.put("BIONIC_FG_ENABLE", "1");
+                    // Resume the persisted in-game multiplier (0 stays Off; the layer still loads so
+                    // the drawer can enable it live via conf.toml hot-reload).
                     writeBionicFgConfig(
-                            0,
+                            resolvedFrameGenSessionMultiplier(),
                             container.getFrameGenFlowScale(),
                             false,
                             0);
@@ -3767,6 +3774,13 @@ return true;
 
     private String resolvedFrameGenEngine() {
         return shortcut != null ? shortcut.getExtra("frameGenEngine", container.getFrameGenEngine()) : container.getFrameGenEngine();
+    }
+
+    // The multiplier frame gen should start at this launch: the persisted value if the user left FG
+    // on, else 0 (Off). Callers gate on an engine actually being selected (bionicFgActive) so the
+    // Edit-screen engine dropdown stays the master switch.
+    private int resolvedFrameGenSessionMultiplier() {
+        return container != null && container.isFrameGenSessionOn() ? container.getFrameGenMultiplier() : 0;
     }
 
     // Resolved ReShade config for this launch: the loadout (ordered effects + per-effect enabled),

--- a/app/src/main/java/com/winlator/star/container/Container.java
+++ b/app/src/main/java/com/winlator/star/container/Container.java
@@ -430,6 +430,19 @@ public class Container {
         putExtra("frameGenFlowScale", String.valueOf(flowScale));
     }
 
+    // Whether frame gen was actually multiplying (in-game multiplier >= 2) when the user last left,
+    // so it can resume next launch instead of always starting Off. Distinct from the engine gate
+    // (frameGenEnabled) and from frameGenMultiplier (which defaults to 2 when unset, so it can't by
+    // itself distinguish "never opted in" from "on at 2x"). Default off — only set once the user
+    // enables FG from the in-game drawer. Honored at launch only when an engine is selected.
+    public boolean isFrameGenSessionOn() {
+        return getExtra("frameGenSessionOn", "0").equals("1");
+    }
+
+    public void setFrameGenSessionOn(boolean on) {
+        putExtra("frameGenSessionOn", on ? "1" : "0");
+    }
+
     // FPS limiter (implemented by the bionic-fg layer: paces the real/base frames, so with
     // frame gen on the on-screen rate is limit × multiplier). Tuned live from the in-game menu.
     public static final int FPS_LIMITER_DEFAULT = 60;

--- a/app/src/main/java/com/winlator/star/ui/AppDrawer.kt
+++ b/app/src/main/java/com/winlator/star/ui/AppDrawer.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.preference.PreferenceManager
 import com.winlator.star.R
 import com.winlator.star.ui.theme.LocalAccentDim
 
@@ -75,6 +76,9 @@ fun AppDrawerContent(
 ) {
     var showHelp by remember { mutableStateOf(false) }
     val context = LocalContext.current
+    val showStores = remember(currentRoute) {
+        PreferenceManager.getDefaultSharedPreferences(context).getBoolean("show_store_features", true)
+    }
 
     if (showHelp) {
         HelpSupportDialog(
@@ -106,9 +110,11 @@ fun AppDrawerContent(
         DrawerItem(Screen.InputControls, currentRoute, onNavigate)
         DrawerItem(Screen.AdrenoTools,   currentRoute, onNavigate)
 
-        DrawerSectionHeader("Stores", note = "· unchanged", showDivider = true)
-        Screen.storeItems.forEach { screen ->
-            DrawerStoreItem(screen, onLaunchStore)
+        if (showStores) {
+            DrawerSectionHeader("Stores", note = "· unchanged", showDivider = true)
+            Screen.storeItems.forEach { screen ->
+                DrawerStoreItem(screen, onLaunchStore)
+            }
         }
 
         HorizontalDivider(

--- a/app/src/main/java/com/winlator/star/ui/XServerDrawer.kt
+++ b/app/src/main/java/com/winlator/star/ui/XServerDrawer.kt
@@ -826,6 +826,14 @@ private fun FrameGenSection(state: XServerDrawerState) {
         ) {
             Column {
                 Spacer(Modifier.height(8.dp))
+                Text(
+                    "Preset",
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 12.sp,
+                    modifier = Modifier.padding(start = 4.dp, bottom = 6.dp)
+                )
+                FgPresetButtons(fgFlow) { fgFlow = it; applyFg() }
+                Spacer(Modifier.height(10.dp))
                 LabeledSlider(
                     "Flow Scale", fgFlow, 0.2f..1.0f,
                     { fgFlow = it }, { applyFg() },
@@ -881,6 +889,49 @@ private fun FgMultiplierButtons(selected: Int, onSelect: (Int) -> Unit) {
                     color = if (isSel) Color.Black else accent,
                     fontSize = 13.sp,
                     fontWeight = if (isSel) FontWeight.Bold else FontWeight.Medium
+                )
+            }
+        }
+    }
+}
+
+// Flow-scale presets, styled like FgMultiplierButtons. Each maps to a fixed flow value; the
+// active chip is the one matching the current flow (epsilon), or none when the slider has been
+// nudged off every preset. Tapping a chip sets that flow value.
+val FG_FLOW_PRESETS = listOf(
+    "Eco" to 0.2f, "Flow" to 0.4f, "Balanced" to 0.6f, "Boost" to 0.8f, "Max" to 1.0f
+)
+
+@Composable
+private fun FgPresetButtons(selectedFlow: Float, onSelect: (Float) -> Unit) {
+    val accent = MaterialTheme.colorScheme.primary
+    val accentDim = LocalAccentDim.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        FG_FLOW_PRESETS.forEach { (label, value) ->
+            val isSel = kotlin.math.abs(selectedFlow - value) < 0.001f
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(if (isSel) accent else Color.Black)
+                    .border(
+                        width = 1.dp,
+                        color = if (isSel) accent else accentDim,
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                    .clickable { onSelect(value) }
+                    .padding(vertical = 9.dp, horizontal = 2.dp)
+            ) {
+                Text(
+                    label,
+                    color = if (isSel) Color.Black else accent,
+                    fontSize = 11.sp,
+                    fontWeight = if (isSel) FontWeight.Bold else FontWeight.Medium,
+                    maxLines = 1
                 )
             }
         }

--- a/app/src/main/java/com/winlator/star/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/winlator/star/ui/screens/SettingsScreen.kt
@@ -108,6 +108,7 @@ fun SettingsScreen(onSaved: () -> Unit = {}) {
 
     var darkMode by remember { mutableStateOf(prefs.getBoolean("dark_mode", false)) }
     var bigPictureMode by remember { mutableStateOf(prefs.getBoolean("enable_big_picture_mode", false)) }
+    var showStoreFeatures by remember { mutableStateOf(prefs.getBoolean("show_store_features", true)) }
     // Default screen the app opens to: "games" (Game Shortcuts, historical default) or "containers".
     var defaultLandingScreen by remember { mutableStateOf(prefs.getString("default_landing_screen", "games") ?: "games") }
     var customApiKeyEnabled by remember { mutableStateOf(prefs.getBoolean("enable_custom_api_key", false)) }
@@ -196,6 +197,7 @@ fun SettingsScreen(onSaved: () -> Unit = {}) {
         editor.putString("fexcore_preset", selectedFEXCorePreset)
         editor.putBoolean("dark_mode", darkMode)
         editor.putBoolean("enable_big_picture_mode", bigPictureMode)
+        editor.putBoolean("show_store_features", showStoreFeatures)
         editor.putString("default_landing_screen", defaultLandingScreen)
         editor.putBoolean("enable_custom_api_key", customApiKeyEnabled)
         if (customApiKeyEnabled) editor.putString("custom_api_key", customApiKey)
@@ -754,6 +756,15 @@ fun SettingsScreen(onSaved: () -> Unit = {}) {
                     onClick = { defaultLandingScreen = "containers" },
                 )
                 Text("Containers", color = MaterialTheme.colorScheme.onSurface, fontSize = 14.sp)
+            }
+        }
+
+        // ── Stores ─────────────────────────────────────────────────────
+        FieldSetLabel("Stores")
+        FieldSet {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = showStoreFeatures, onCheckedChange = { showStoreFeatures = it })
+                Text("Show store integrations (Steam, GOG, Epic, Amazon)", color = MaterialTheme.colorScheme.onSurface, fontSize = 14.sp)
             }
         }
 

--- a/app/src/main/java/com/winlator/star/ui/screens/ShortcutsScreen.kt
+++ b/app/src/main/java/com/winlator/star/ui/screens/ShortcutsScreen.kt
@@ -1128,6 +1128,10 @@ private fun ShortcutSettingsDialogScreen(shortcut: Shortcut, onDismiss: () -> Un
     var showDxvkDownloadSheet by remember { mutableStateOf(false) }
     var showVegasDownloadSheet by remember { mutableStateOf(false) }
     var showVkd3dDownloadSheet by remember { mutableStateOf(false) }
+    // Bumped by the download sheets' onContentChanged so the version lists below (and
+    // DxvkConfigDialog's internal ones) reload live — without this, a newly downloaded
+    // component only appears after closing and reopening the whole settings dialog.
+    var contentRefreshKey by remember { mutableStateOf(0) }
 
     // Tab
     var selectedTab by remember { mutableIntStateOf(0) }
@@ -1159,8 +1163,10 @@ private fun ShortcutSettingsDialogScreen(shortcut: Shortcut, onDismiss: () -> Un
     }
     var showIconPickMenu by remember { mutableStateOf(false) }
 
-    // Load async data
-    LaunchedEffect(Unit) {
+    // Load the Box64/FEXCore version lists. Keyed on contentRefreshKey so a download/remove in
+    // the content sheets re-scans installed profiles live; selection initialization stays in the
+    // one-shot LaunchedEffect(Unit) below so a refresh never clobbers unsaved dropdown choices.
+    LaunchedEffect(contentRefreshKey) {
         withContext(Dispatchers.IO) {
             val cm = ContentsManager(context)
             cm.syncContents()
@@ -1182,6 +1188,18 @@ private fun ShortcutSettingsDialogScreen(shortcut: Shortcut, onDismiss: () -> Un
                 fexList.add(n.substring(n.indexOf('-') + 1))
             }
 
+            withContext(Dispatchers.Main) {
+                isArm64EC = arm64ec
+                box64Versions = b64Arr
+                fexCoreVersions = fexList
+                if (selectedBox64Version.isEmpty()) selectedBox64Version = b64Arr.firstOrNull() ?: ""
+            }
+        }
+    }
+
+    // Load async data
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
             val b64Presets = Box64PresetManager.getPresets("box64", context)
             val fexPresets = FEXCorePresetManager.getPresets(context)
             val profiles = InputControlsManager(context).getProfiles(true)
@@ -1191,9 +1209,6 @@ private fun ShortcutSettingsDialogScreen(shortcut: Shortcut, onDismiss: () -> Un
             if (sfDir.exists()) sfDir.listFiles()?.forEach { midi.add(it.name) }
 
             withContext(Dispatchers.Main) {
-                isArm64EC = arm64ec
-                box64Versions = b64Arr
-                fexCoreVersions = fexList
                 box64Presets = b64Presets
                 fexCorePresets = fexPresets
                 controlsProfiles = profiles
@@ -1208,8 +1223,6 @@ private fun ShortcutSettingsDialogScreen(shortcut: Shortcut, onDismiss: () -> Un
                 val cpId = shortcut.getExtra("controlsProfile", "0").toIntOrNull() ?: 0
                 selectedControlsProfileIndex = if (cpId == 0) 0
                     else profiles.indexOfFirst { it.id == cpId }.let { if (it >= 0) it + 1 else 0 }
-
-                if (selectedBox64Version.isEmpty()) selectedBox64Version = b64Arr.firstOrNull() ?: ""
             }
         }
     }
@@ -1697,6 +1710,7 @@ private fun ShortcutSettingsDialogScreen(shortcut: Shortcut, onDismiss: () -> Un
         DxvkConfigDialog(
             isArm64EC = isArm64EC,
             isVegas = isVegasCfg,
+            refreshKey = contentRefreshKey,
             initialConfig = dxWrapperConfig,
             onConfirm = { dxWrapperConfig = it; showDxvkConfig = false },
             onDismiss = { showDxvkConfig = false },
@@ -1714,36 +1728,39 @@ private fun ShortcutSettingsDialogScreen(shortcut: Shortcut, onDismiss: () -> Un
 
     if (showBox64DownloadSheet) {
         ContentDownloadSheet(
-            contentType = com.winlator.star.contents.ContentProfile.ContentType.CONTENT_TYPE_BOX64,
+            contentType = if (isArm64EC)
+                com.winlator.star.contents.ContentProfile.ContentType.CONTENT_TYPE_WOWBOX64
+            else
+                com.winlator.star.contents.ContentProfile.ContentType.CONTENT_TYPE_BOX64,
             onDismiss = { showBox64DownloadSheet = false },
-            onContentChanged = {}
+            onContentChanged = { contentRefreshKey++ }
         )
     }
     if (showFexCoreDownloadSheet) {
         ContentDownloadSheet(
             contentType = com.winlator.star.contents.ContentProfile.ContentType.CONTENT_TYPE_FEXCORE,
             onDismiss = { showFexCoreDownloadSheet = false },
-            onContentChanged = {}
+            onContentChanged = { contentRefreshKey++ }
         )
     }
     if (showDxvkDownloadSheet) {
         ContentDownloadSheet(
             contentType = com.winlator.star.contents.ContentProfile.ContentType.CONTENT_TYPE_DXVK,
             onDismiss = { showDxvkDownloadSheet = false },
-            onContentChanged = {}
+            onContentChanged = { contentRefreshKey++ }
         )
     }
     if (showVkd3dDownloadSheet) {
         ContentDownloadSheet(
             contentType = com.winlator.star.contents.ContentProfile.ContentType.CONTENT_TYPE_VKD3D,
             onDismiss = { showVkd3dDownloadSheet = false },
-            onContentChanged = {}
+            onContentChanged = { contentRefreshKey++ }
         )
     }
     if (showVegasDownloadSheet) {
         VegasDownloadSheet(
             onDismiss = { showVegasDownloadSheet = false },
-            onContentChanged = {}
+            onContentChanged = { contentRefreshKey++ }
         )
     }
     } // settings Dialog

--- a/app/src/main/java/com/winlator/star/widget/FrameRating.java
+++ b/app/src/main/java/com/winlator/star/widget/FrameRating.java
@@ -338,9 +338,13 @@ public class FrameRating extends FrameLayout implements Runnable {
                 long microAmps = bm.getLongProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW);
                 int voltageMv = batteryStatus.getIntExtra(BatteryManager.EXTRA_VOLTAGE, 0);
                 
-                // Only show positive discharge wattage; if charging (microAmps > 0), show 0W
-                if (microAmps < 0) {
-                    batteryWattage = (Math.abs(microAmps) * voltageMv) / 1000000000.0f;
+                // Show draw magnitude regardless of the device's current-sign convention
+                // (some report discharge negative, others positive), so it isn't stuck at 0.
+                // MIN_VALUE = unsupported; small magnitude = mA-reporting unit, scale to µA.
+                if (microAmps != 0 && microAmps != Long.MIN_VALUE) {
+                    long absUa = Math.abs(microAmps);
+                    if (absUa < 10000) absUa *= 1000;
+                    batteryWattage = (absUa * voltageMv) / 1000000000.0f;
                 } else {
                     batteryWattage = 0.0f;
                 }

--- a/app/src/main/java/com/winlator/star/widget/HudMetrics.java
+++ b/app/src/main/java/com/winlator/star/widget/HudMetrics.java
@@ -26,32 +26,66 @@ public class HudMetrics {
 
     public HudMetrics(Context context) { this.context = context; }
 
-    // ---- CPU usage % (/proc/stat aggregate delta) -------------------------
-    private long prevCpuTotal = 0, prevCpuIdle = 0;
+    // ---- CPU usage % (emulator process-tree delta) ------------------------
+    // The global /proc/stat aggregate is unreadable to apps on modern Android
+    // (SELinux proc_stat + hidepid=invisible), so measure the emulator's own CPU
+    // instead: sum utime+stime across our visible (same-UID) process tree — the
+    // app plus its wine/box64/proot children — and delta against wall-clock. This
+    // is the meaningful number for a game HUD and works without root.
+    private long prevCpuTicks = 0, prevWallNs = 0;
+    private boolean cpuBaselineSet = false;
+    private static final long CLK_TCK =
+        Math.max(1, android.system.Os.sysconf(android.system.OsConstants._SC_CLK_TCK));
 
-    /** Overall device CPU usage 0..100, computed from the delta since the last call. */
+    /** Emulator CPU usage 0..100 (share of total capacity), delta since the last call. */
     public float getCPUUsage() {
-        try (BufferedReader r = new BufferedReader(new FileReader("/proc/stat"))) {
-            String line = r.readLine();
-            if (line == null || !line.startsWith("cpu ")) return 0;
-            String[] p = line.trim().split("\\s+");
-            long total = 0, idle = 0;
-            // fields: user nice system idle iowait irq softirq steal ...
-            for (int i = 1; i < p.length; i++) {
-                long v = Long.parseLong(p[i]);
-                total += v;
-                if (i == 4 || i == 5) idle += v; // idle + iowait
-            }
-            long dTotal = total - prevCpuTotal;
-            long dIdle = idle - prevCpuIdle;
-            prevCpuTotal = total;
-            prevCpuIdle = idle;
-            if (dTotal <= 0) return 0;
-            float usage = (dTotal - dIdle) * 100f / dTotal;
+        try {
+            long ticks = readProcessTreeCpuTicks();
+            long nowNs = SystemClock.elapsedRealtimeNanos();
+            long dTicks = ticks - prevCpuTicks;
+            long dWallNs = nowNs - prevWallNs;
+            boolean hadBaseline = cpuBaselineSet;
+            prevCpuTicks = ticks;
+            prevWallNs = nowNs;
+            cpuBaselineSet = true;
+            if (!hadBaseline || dWallNs <= 0 || dTicks < 0) return 0; // first call: only seed baseline
+            int nCores = Math.max(1, Runtime.getRuntime().availableProcessors());
+            double cpuNs = dTicks * (1_000_000_000.0 / CLK_TCK);
+            float usage = (float) (cpuNs * 100.0 / ((double) dWallNs * nCores));
             return Math.max(0, Math.min(100, usage));
         } catch (Exception e) {
             return 0;
         }
+    }
+
+    /** Sum of utime+stime (clock ticks) across all PID dirs visible under /proc. */
+    private long readProcessTreeCpuTicks() {
+        long sum = 0;
+        File proc = new File("/proc");
+        File[] entries = proc.listFiles();
+        if (entries == null) return prevCpuTicks; // keep last -> 0 delta rather than a spike
+        for (File d : entries) {
+            String name = d.getName();
+            boolean numeric = !name.isEmpty();
+            for (int i = 0; numeric && i < name.length(); i++)
+                if (!Character.isDigit(name.charAt(i))) numeric = false;
+            if (!numeric) continue;
+            try (BufferedReader r = new BufferedReader(new FileReader(new File(d, "stat")))) {
+                String line = r.readLine();
+                if (line == null) continue;
+                // Fields 14 (utime) + 15 (stime) are the 12th/13th tokens AFTER the
+                // ')' that closes comm — parsing from there avoids comm's spaces/parens.
+                int close = line.lastIndexOf(')');
+                if (close < 0 || close + 2 >= line.length()) continue;
+                String[] f = line.substring(close + 2).trim().split("\\s+");
+                // post-comm index 0 = state (field 3); utime = field 14 -> index 11,
+                // stime = field 15 -> index 12.
+                if (f.length > 12) sum += Long.parseLong(f[11]) + Long.parseLong(f[12]);
+            } catch (Exception ignored) {
+                // process vanished mid-scan or stat unreadable — skip it.
+            }
+        }
+        return sum;
     }
 
     // ---- GPU load % (ported from FrameRating) -----------------------------
@@ -187,9 +221,19 @@ public class HudMetrics {
         } else {
             microAmps = readCurrentNowFallback();
         }
+        // Show draw magnitude regardless of the device's current-sign convention:
+        // some report discharge as negative, others (this Xiaomi) as positive, so
+        // keying on microAmps < 0 left watts stuck at 0 on the latter. The `charging`
+        // flag (from EXTRA_PLUGGED) still drives the CHG/PWR label in the HUD.
+        // BATTERY_PROPERTY_CURRENT_NOW returns Long.MIN_VALUE when unsupported.
         float watts = 0f;
-        if (microAmps < 0) {
-            watts = (Math.abs(microAmps) * (float) voltageMv) / 1_000_000_000.0f;
+        if (microAmps != 0 && microAmps != Long.MIN_VALUE) {
+            long absUa = Math.abs(microAmps);
+            // Spec unit is µA, but some Xiaomi/MTK units report mA here, which would
+            // round to ~0.0W. Under a running game the draw is always >10mA, so an
+            // implausibly small magnitude means mA — scale it up to µA.
+            if (absUa < 10_000) absUa *= 1000;
+            watts = (absUa * (float) voltageMv) / 1_000_000_000.0f;
         }
         return new Battery(watts, charging);
     }

--- a/app/src/main/java/com/winlator/star/xenvironment/ImageFsInstaller.java
+++ b/app/src/main/java/com/winlator/star/xenvironment/ImageFsInstaller.java
@@ -37,12 +37,35 @@ public abstract class ImageFsInstaller {
         }
     }
 
+    // The imagefs ships a build-time libjpeg.so -> libjpeg.so.8 symlink. Nothing resolves the bare
+    // "libjpeg.so" name at runtime (real consumers ask for libjpeg.so.8), but on Xiaomi/HyperOS the
+    // symlink is actively harmful: their patched libhwui.so drags /system_ext/lib64/libjpeg-hyper.so
+    // into any dlopen closure that touches libandroid.so — both frame-gen layers do, for
+    // AHardwareBuffer — and libjpeg-hyper's own "libjpeg.so" dependency then resolves (via
+    // LD_LIBRARY_PATH) to our symlinked copy, which does not export the jsimd_* SIMD symbols it
+    // needs. The failed relocation aborts the entire dlopen, so bionic-fg AND lsfg-vk silently
+    // never load on those devices ("Requested layer ... failed to load"). Dropping the symlink
+    // lets the linker fall through to Xiaomi's /system/lib64/libjpeg.so, which exports them.
+    // Only done when libjpeg-hyper is present so non-Xiaomi devices keep the imagefs untouched.
+    public static void removeLibjpegShadowIfXiaomi(ImageFs imageFs) {
+        try {
+            if (!new File("/system_ext/lib64/libjpeg-hyper.so").exists()) return;
+            File shadow = new File(imageFs.getLibDir(), "libjpeg.so");
+            if (shadow.exists() && shadow.delete()) {
+                Log.i("ImageFsInstaller", "Removed usr/lib/libjpeg.so symlink (Xiaomi libjpeg-hyper workaround)");
+            }
+        } catch (Exception e) {
+            Log.e("ImageFsInstaller", "Failed to remove libjpeg.so shadow symlink", e);
+        }
+    }
+
     // Stages the bundled bionic-fg Vulkan layer (.so + implicit-layer manifest) into imagefs so
     // frame generation / the FPS limiter work without manually copying the .so after every
     // (re)install. Idempotent: skips the .so copy when it is already present with the same size.
     // The manifest's library_path is ../../../lib/libbionic_fg.so, so it must sit in
     // usr/share/vulkan/implicit_layer.d/ with the .so in usr/lib/.
     public static void installBionicFgLayer(Context context, ImageFs imageFs) {
+        removeLibjpegShadowIfXiaomi(imageFs);
         try {
             File soDst = new File(imageFs.getLibDir(), "libbionic_fg.so");
             long assetSize = FileUtils.getSize(context, "bionic-fg/libbionic_fg.so");

--- a/patches/bionic-fg-bannerlator-fixes.patch
+++ b/patches/bionic-fg-bannerlator-fixes.patch
@@ -16,7 +16,7 @@ index 032a00e..afdb0c3 100644
      }
  }
 diff --git a/src/framegen_context.cpp b/src/framegen_context.cpp
-index 27e2f58..11781ac 100644
+index 27e2f58..0d58aeb 100644
 --- a/src/framegen_context.cpp
 +++ b/src/framegen_context.cpp
 @@ -188,6 +188,7 @@ static Pass makeModel1Pass(const vk::Device& dev,
@@ -42,8 +42,33 @@ index 27e2f58..11781ac 100644
          ctx->cmdPool_       = vk::CommandPool(ctx->device_);
          ctx->linearSampler_ = vk::Sampler(ctx->device_, VK_FILTER_LINEAR,
                                             VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER);
+@@ -871,6 +878,7 @@ void FramegenContext::present(AHardwareBuffer* newPrev, AHardwareBuffer* newCurr
+ 
+         fr.cmd.end();
+         fr.cmd.submit(device_, fr.fence.handle());
++        lastSubmitFence_ = fr.fence.handle();
+         frameIdx_++;
+         return;
+     }
+@@ -958,10 +966,16 @@ void FramegenContext::present(AHardwareBuffer* newPrev, AHardwareBuffer* newCurr
+ 
+     fr.cmd.end();
+     fr.cmd.submit(device_, fr.fence.handle());
++    lastSubmitFence_ = fr.fence.handle();
+     frameIdx_++;
+ }
+ #endif // __ANDROID__
+ 
++bool FramegenContext::waitLastDispatch(uint64_t timeoutNs) {
++    if (!device_.valid() || lastSubmitFence_ == VK_NULL_HANDLE) return true;
++    return vkWaitForFences(device_.handle(), 1, &lastSubmitFence_, VK_TRUE, timeoutNs) == VK_SUCCESS;
++}
++
+ void FramegenContext::updateConfig(const Config& cfg) {
+     cfg_ = cfg; cfg_.sanitize();
+     for (size_t k=0;k<uboSynth_.size();++k) {
 diff --git a/src/framegen_context.hpp b/src/framegen_context.hpp
-index 7175d1f..492a024 100644
+index 7175d1f..19bd92a 100644
 --- a/src/framegen_context.hpp
 +++ b/src/framegen_context.hpp
 @@ -56,7 +56,12 @@ public:
@@ -59,6 +84,31 @@ index 7175d1f..492a024 100644
          AHardwareBuffer* prevAhb,
          AHardwareBuffer* currAhb,
          const std::vector<AHardwareBuffer*>& outputAhbs,
+@@ -71,6 +76,13 @@ public:
+     void waitIdle();
+     void destroy();
+ 
++    // Waits (bounded) for the compute dispatch submitted by the most recent
++    // present() call to finish, without draining any other work on the
++    // shared queue/device the way waitIdle() does. Returns false on timeout
++    // (caller should treat the dispatch's output as not-yet-ready). Returns
++    // true if nothing has been submitted yet.
++    bool waitLastDispatch(uint64_t timeoutNs);
++
+     bool        valid()    const { return device_.valid(); }
+     std::string describe() const;
+ 
+@@ -172,6 +184,10 @@ private:
+     Frame    frames_[2];
+     uint32_t frameIdx_ = 0;
+ 
++    // Fence of the most recent present() dispatch submission (not owned —
++    // aliases one of frames_[].fence). Backs waitLastDispatch().
++    VkFence  lastSubmitFence_ = VK_NULL_HANDLE;
++
+ #ifdef __ANDROID__
+     AHardwareBuffer* prevAhbPtr_ = nullptr;
+     AHardwareBuffer* currAhbPtr_ = nullptr;
 diff --git a/src/jni_bridge.cpp b/src/jni_bridge.cpp
 index b7f3e03..e5fa182 100644
 --- a/src/jni_bridge.cpp
@@ -75,7 +125,7 @@ index b7f3e03..e5fa182 100644
      if (!ctx) { BFG_LOGE("nativeCreateContext: FramegenContext::create failed"); return 0L; }
      return bionic_fg::ctxToHandle(ctx.release());
 diff --git a/src/vk_layer/layer.cpp b/src/vk_layer/layer.cpp
-index 66d1934..da4c5ce 100644
+index 66d1934..d54dcd0 100644
 --- a/src/vk_layer/layer.cpp
 +++ b/src/vk_layer/layer.cpp
 @@ -16,6 +16,7 @@
@@ -209,7 +259,7 @@ index 66d1934..da4c5ce 100644
      VkExtent2D extent = {};
      VkFormat   format = VK_FORMAT_UNDEFINED;
      std::vector<VkImage> images;
-@@ -415,6 +474,22 @@ struct SwapState {
+@@ -415,6 +474,26 @@ struct SwapState {
  
      uint64_t frameCount = 0;
      bool     inPresent  = false;
@@ -219,6 +269,10 @@ index 66d1934..da4c5ce 100644
 +    // disabled once either reaches kMaxFenceTimeouts.
 +    uint32_t copyFenceTimeouts = 0;
 +    uint32_t genFenceTimeouts  = 0;
++    // Consecutive timeouts waiting on the framegen compute dispatch's own
++    // completion fence (waitLastDispatch(), not the old full-queue waitIdle()).
++    // Independent counter for the same reason as the two above.
++    uint32_t dispatchFenceTimeouts = 0;
 +    // Sticky, runtime-only kill switch: once the present-path proves sync-
 +    // incompatible with this ICD we passthrough for the rest of THIS swapchain's
 +    // life. Kept separate from conf.enabled (which the file owns) so a conf.toml
@@ -232,7 +286,7 @@ index 66d1934..da4c5ce 100644
  
      void cleanup(const DeviceData& dd, VkDevice dev) {
          if (dd.deviceWaitIdle) dd.deviceWaitIdle(dev);
-@@ -455,7 +530,13 @@ static std::unique_ptr<bionic_fg::FramegenContext> createFramegenContext(
+@@ -455,7 +534,13 @@ static std::unique_ptr<bionic_fg::FramegenContext> createFramegenContext(
          const SwapState& st,
          const LayerConf& conf) {
      DisableLayerEnvGuard disableLayerForInternalVulkan;
@@ -246,7 +300,7 @@ index 66d1934..da4c5ce 100644
          st.prevAhb,
          st.currAhb,
          st.outAhbs,
-@@ -897,6 +978,15 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_CreateSwapchainKHR(
+@@ -897,6 +982,15 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_CreateSwapchainKHR(
          cpci.flags            = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
          dd.createCmdPool(device, &cpci, nullptr, &st.copyPool);
  
@@ -262,7 +316,7 @@ index 66d1934..da4c5ce 100644
          VkCommandBufferAllocateInfo cbai{};
          cbai.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
          cbai.commandPool        = st.copyPool;
-@@ -1031,6 +1121,91 @@ static VkResult acquireGeneratedImage(const DeviceData& dd, VkDevice device,
+@@ -1031,6 +1125,91 @@ static VkResult acquireGeneratedImage(const DeviceData& dd, VkDevice device,
  
  // ─── QueuePresentKHR ──────────────────────────────────────────────────────────
  
@@ -354,7 +408,7 @@ index 66d1934..da4c5ce 100644
  VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
          VkQueue queue,
          const VkPresentInfoKHR* pPresentInfo) {
-@@ -1122,7 +1297,42 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1122,7 +1301,42 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
          }
      }
  
@@ -398,7 +452,7 @@ index 66d1934..da4c5ce 100644
          return callNextPresent(queue, pPresentInfo);
      if (imgIdx >= st.images.size()) {
          BFG_LAYER_E("present image index %u out of range (%zu); passing through", imgIdx, st.images.size());
-@@ -1155,8 +1365,13 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1155,8 +1369,13 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
      // --- Step 1: Copy real swapchain image into current AHB input. The copy
      // waits on the application's original present semaphores, so the final real
      // present must not wait on those same binary semaphores again.
@@ -414,7 +468,7 @@ index 66d1934..da4c5ce 100644
          BFG_LAYER_E("copy fence wait/reset failed; passing through");
          return callNextPresent(queue, pPresentInfo);
      }
-@@ -1234,11 +1449,18 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1234,16 +1453,34 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
          finalPresent.pWaitSemaphores = nullptr;
      }
  
@@ -435,7 +489,24 @@ index 66d1934..da4c5ce 100644
  
      // --- Step 2: Run framegen after we have both previous and current inputs.
      if (st.frameCount > 0) {
-@@ -1267,7 +1489,25 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+         st.fgCtx->present(st.prevAhb, st.currAhb);
+-        st.fgCtx->waitIdle();
++        // Bound to just THIS dispatch's own completion fence instead of a full
++        // vkQueueWaitIdle() on the shared queue: in single-device mode that
++        // queue is also the app's own render queue on GPUs with one universal
++        // queue family (the common mobile case), so waitIdle() was draining the
++        // game's own in-flight work every present, not just ours. On timeout,
++        // degrade to a real-frame present this cycle instead of blitting from
++        // an output whose completion isn't proven.
++        if (!st.fgCtx->waitLastDispatch(syncFenceTimeoutNs(st.conf))) {
++            BFG_LAYER_E("framegen dispatch fence wait timed out; skipping generated frames this present");
++            noteFenceTimeout(st, st.dispatchFenceTimeouts, "framegen-dispatch");
++        } else {
++        st.dispatchFenceTimeouts = 0;   // dispatch fence signalled; sync working
+         for (auto& out : st.outProducerImgs) {
+             out.layout = VK_IMAGE_LAYOUT_GENERAL;
+             out.externalOwner = true;
+@@ -1267,7 +1504,25 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
                  continue;
              }
  
@@ -462,7 +533,7 @@ index 66d1934..da4c5ce 100644
              dd.resetFences(device, 1, &st.genFences[k]);
              VkCommandBuffer genCmd = st.genCmds[k];
              dd.resetCmdBuf(genCmd, 0);
-@@ -1338,6 +1578,17 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1338,8 +1593,20 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
              genPresent.swapchainCount     = 1;
              genPresent.pSwapchains        = &swapchain;
              genPresent.pImageIndices      = &genIdx;
@@ -479,7 +550,10 @@ index 66d1934..da4c5ce 100644
 +            }
              dd.queuePresent(queue, &genPresent);
          }
++        }
      }
+ 
+     std::swap(st.prevAhb, st.currAhb);
 diff --git a/src/vulkan/vk_impl.cpp b/src/vulkan/vk_impl.cpp
 index 4f864eb..aaa1bb0 100644
 --- a/src/vulkan/vk_impl.cpp

--- a/patches/bionic-fg-bannerlator-fixes.patch
+++ b/patches/bionic-fg-bannerlator-fixes.patch
@@ -125,7 +125,7 @@ index b7f3e03..e5fa182 100644
      if (!ctx) { BFG_LOGE("nativeCreateContext: FramegenContext::create failed"); return 0L; }
      return bionic_fg::ctxToHandle(ctx.release());
 diff --git a/src/vk_layer/layer.cpp b/src/vk_layer/layer.cpp
-index 66d1934..d54dcd0 100644
+index 66d1934..4c7f1c1 100644
 --- a/src/vk_layer/layer.cpp
 +++ b/src/vk_layer/layer.cpp
 @@ -16,6 +16,7 @@
@@ -316,7 +316,31 @@ index 66d1934..d54dcd0 100644
          VkCommandBufferAllocateInfo cbai{};
          cbai.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
          cbai.commandPool        = st.copyPool;
-@@ -1031,6 +1125,91 @@ static VkResult acquireGeneratedImage(const DeviceData& dd, VkDevice device,
+@@ -1013,14 +1107,21 @@ static VkResult callNextPresent(VkQueue queue, const VkPresentInfoKHR* presentIn
+ static VkResult acquireGeneratedImage(const DeviceData& dd, VkDevice device,
+                                       VkSwapchainKHR swapchain, VkSemaphore signalSemaphore,
+                                       uint32_t* imageIndex) {
++    // Pace generated presents by blocking until the presentation engine releases
++    // the next FIFO slot/image instead of best-effort grabbing whatever is
++    // immediately available. This mirrors lsfg-vk's Android path and avoids the
++    // bursty "present everything right now or skip it" behavior from timeout=0.
++    constexpr uint64_t kAcquireTimeoutNs = UINT64_MAX;
++
+     if (dd.acquireNextImage) {
+-        return dd.acquireNextImage(device, swapchain, 0, signalSemaphore, VK_NULL_HANDLE, imageIndex);
++        return dd.acquireNextImage(device, swapchain, kAcquireTimeoutNs,
++                                   signalSemaphore, VK_NULL_HANDLE, imageIndex);
+     }
+     if (dd.acquireNextImage2) {
+         VkAcquireNextImageInfoKHR info{};
+         info.sType      = VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHR;
+         info.swapchain  = swapchain;
+-        info.timeout    = 0;
++        info.timeout    = kAcquireTimeoutNs;
+         info.semaphore  = signalSemaphore;
+         info.fence      = VK_NULL_HANDLE;
+         info.deviceMask = 1;
+@@ -1031,6 +1132,91 @@ static VkResult acquireGeneratedImage(const DeviceData& dd, VkDevice device,
  
  // ─── QueuePresentKHR ──────────────────────────────────────────────────────────
  
@@ -408,7 +432,7 @@ index 66d1934..d54dcd0 100644
  VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
          VkQueue queue,
          const VkPresentInfoKHR* pPresentInfo) {
-@@ -1122,7 +1301,42 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1122,7 +1308,42 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
          }
      }
  
@@ -452,7 +476,7 @@ index 66d1934..d54dcd0 100644
          return callNextPresent(queue, pPresentInfo);
      if (imgIdx >= st.images.size()) {
          BFG_LAYER_E("present image index %u out of range (%zu); passing through", imgIdx, st.images.size());
-@@ -1155,8 +1369,13 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1155,8 +1376,13 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
      // --- Step 1: Copy real swapchain image into current AHB input. The copy
      // waits on the application's original present semaphores, so the final real
      // present must not wait on those same binary semaphores again.
@@ -468,7 +492,7 @@ index 66d1934..d54dcd0 100644
          BFG_LAYER_E("copy fence wait/reset failed; passing through");
          return callNextPresent(queue, pPresentInfo);
      }
-@@ -1234,16 +1453,34 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1234,16 +1460,34 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
          finalPresent.pWaitSemaphores = nullptr;
      }
  
@@ -506,7 +530,7 @@ index 66d1934..d54dcd0 100644
          for (auto& out : st.outProducerImgs) {
              out.layout = VK_IMAGE_LAYOUT_GENERAL;
              out.externalOwner = true;
-@@ -1267,7 +1504,25 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1267,7 +1511,25 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
                  continue;
              }
  
@@ -533,7 +557,7 @@ index 66d1934..d54dcd0 100644
              dd.resetFences(device, 1, &st.genFences[k]);
              VkCommandBuffer genCmd = st.genCmds[k];
              dd.resetCmdBuf(genCmd, 0);
-@@ -1338,8 +1593,20 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
+@@ -1338,8 +1600,20 @@ VKAPI_ATTR VkResult VKAPI_CALL BionicFG_QueuePresentKHR(
              genPresent.swapchainCount     = 1;
              genPresent.pSwapchains        = &swapchain;
              genPresent.pImageIndices      = &genIdx;


### PR DESCRIPTION
## Summary

A curated set of fixes and small features developed downstream, cherry-picked cleanly onto `main` (build-verified with `assembleStandardRelease`).

### bionic-fg (native, present-path)

* Replace `vkQueueWaitIdle()` with a bounded wait on the frame-generation dispatch fence in the present path. This avoids unnecessarily draining the game's in-flight work after each frame-generation compute dispatch on GPUs with a single universal queue family (most Adreno/Turnip), improving frame-generation performance in heavy DXVK titles.
* Block generated-frame acquire under `VK_PRESENT_MODE_FIFO_KHR` to ensure generated frames are acquired in sync with FIFO presentation pacing.
* Remove the `libjpeg` symlink shadow on Xiaomi so the frame-generation Vulkan layer loads correctly. On Xiaomi/HyperOS, `libhwui.so` pulls `libjpeg-hyper.so` into the layer's `dlopen()` closure, which resolves `libjpeg.so` to a bundled symlink missing the required `jsimd_*` symbols, causing `VK_LAYER_BIONIC_framegen` to fail loading. This workaround is gated to Xiaomi devices and is a no-op elsewhere.

### HUD

* Fix CPU% and battery wattage showing `0` on Xiaomi and newer Android versions. CPU usage now sums `utime + stime` across the emulator's visible process tree instead of reading the SELinux-blocked global `/proc/stat`. Battery power is now computed sign-agnostically (some devices report discharge current as positive) and includes a Xiaomi µA/mA unit quirk guard.
* **Note:** The HUD CPU% now reports the emulator process-tree's CPU usage rather than total device CPU usage. As a result, the displayed values will generally be lower than in previous releases, but they more accurately reflect the emulator's actual CPU utilization.

### Frame-gen UX

* Persist the in-game frame-generation on/off state across launches instead of always starting disabled.
* Add a Flow Scale preset row (Eco, Flow, Balanced, Boost, Max) above the existing Flow Scale slider in the drawer.

### Small fixes

* Refresh the DXVK, VKD3D, Box64, and FEXCore version dropdowns immediately after a download sheet closes instead of requiring the Settings dialog to be reopened.
* Fix the Box64 download sheet using the correct content type for arm64ec containers (`WOWBOX64` instead of `BOX64`).
* Add a drawer toggle to hide store integrations (Steam, GOG, Epic, Amazon) for users who do not use them.
