### PR TITLE
fix(epic): prevent library crash from duplicate game entries

### DIFF
--- a/app/src/main/java/com/winlator/star/store/EpicGamesActivity.kt
+++ b/app/src/main/java/com/winlator/star/store/EpicGamesActivity.kt
@@ -245,7 +245,9 @@ class EpicGamesActivity : ComponentActivity() {
                 dlcEd.putString("epic_dlcs_$key", value.toString())
             }
             dlcEd.apply()
-            val displayGames = if (mainGames.isEmpty()) rawGames else mainGames
+            val displayGames = (if (mainGames.isEmpty()) rawGames else mainGames)
+                .distinctBy { it.appName }
+                .toMutableList()
 
             displayGames.sortWith { a, b -> a.title.compareTo(b.title, ignoreCase = true) }
 
@@ -551,7 +553,7 @@ class EpicGamesActivity : ComponentActivity() {
                 g.canRunOffline = j.optBoolean("canRunOffline", true)
                 list.add(g)
             }
-            list
+            list.distinctBy { it.appName }
         } catch (e: Exception) { Log.e(TAG, "loadCachedGames failed", e); null }
     }
 


### PR DESCRIPTION
Opening the Epic Games library crashed immediately, preventing the screen from loading.

Device logcat reported:

`IllegalArgumentException: Key "Dodo" was already used`

Testing the live Epic library API confirmed inconsistent pagination: the first response contained 107 records while the next cursor restarted at offset 100. The same Borderlands 2 entitlement (`appName: Dodo`) was returned on pages 0 and 2 with an identical namespace and catalog ID.

Since the Compose lists use `appName` as their item key, the duplicate caused the crash. The fix deduplicates fresh API results and cached entries by `appName` before rendering, also repairing existing affected caches.

Tested with `./gradlew assembleDebug` and verified on the affected device.