### PR TITLE
Fix crash/leak/hang chain in X server + renderer (contributor ERL, issues #1-9)

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -47,6 +47,20 @@ target_link_libraries(winlator
         adrenotools
 )
 
+# DrawableBufferPool native heap (ERL bug report #2): tiny dependency-free lib
+# (libc + JNI only) backing the X-server Drawable buffer pool with calloc/free in
+# the native heap, bypassing ART's small non-compacting non-moving space which
+# fragments under cursor/drawable churn. Own .so so it stays off every other path.
+add_library(drawablepool SHARED
+        winlator/drawablepool.c
+)
+
+target_compile_options(drawablepool PRIVATE -Wall -Wextra)
+
+target_link_libraries(drawablepool
+        log
+)
+
 # Add Fake Input library for controller emulation (loaded via LD_PRELOAD)
 add_library(fakeinput SHARED
         winlator/fakeinput.cpp

--- a/app/src/main/cpp/winlator/VulkanRendererContext.cpp
+++ b/app/src/main/cpp/winlator/VulkanRendererContext.cpp
@@ -760,7 +760,12 @@ void VulkanRendererContext::endOneTime(VkCommandBuffer cb) {
     VkSubmitInfo si{}; si.sType=VK_STRUCTURE_TYPE_SUBMIT_INFO; si.commandBufferCount=1; si.pCommandBuffers=&cb;
     VkFenceCreateInfo fi{}; fi.sType=VK_STRUCTURE_TYPE_FENCE_CREATE_INFO; VkFence fence;
     vk_.CreateFence(device,&fi,nullptr,&fence);
-    vk_.QueueSubmit(graphicsQueue,1,&si,fence); vk_.WaitForFences(device,1,&fence,VK_TRUE,UINT64_MAX);
+    vk_.QueueSubmit(graphicsQueue,1,&si,fence);
+    // ERL bug report #9: bound the wait so a never-signalling fence can't hang the render
+    // thread forever with no log output (was UINT64_MAX).
+    if (vk_.WaitForFences(device,1,&fence,VK_TRUE,2000000000ULL) != VK_SUCCESS) {
+        RLOG_E("endOneTime: fence wait timed out after 2s");
+    }
     vk_.DestroyFence(device,fence,nullptr); vk_.FreeCommandBuffers(device,cmdPool,1,&cb);
 }
 
@@ -1500,7 +1505,17 @@ void VulkanRendererContext::renderFrame() {
     if (surfaceWidth==0||surfaceHeight==0) return;
 
     if (fbResized.load()) {
-        for (auto& f:inFlightFences) vk_.WaitForFences(device,1,&f,VK_TRUE,UINT64_MAX);
+        // ERL bug report #9: on timeout, do NOT proceed to cleanupSwapchain() (which would
+        // destroy resources possibly still in flight) - leave fbResized true and retry next frame.
+        bool fencesOk = true;
+        for (auto& f:inFlightFences) {
+            if (vk_.WaitForFences(device,1,&f,VK_TRUE,2000000000ULL) != VK_SUCCESS) {
+                RLOG_E("renderFrame: fence wait timed out during resize (2s) - deferring swapchain recreation");
+                fencesOk = false;
+                break;
+            }
+        }
+        if (!fencesOk) return;
         cleanupSwapchain();
         bool ok=false;
         try{createSwapchain();createFramebuffers();createCmdBufs();imgInFlight.assign(swapchainImages.size(),VK_NULL_HANDLE);
@@ -1512,12 +1527,16 @@ ok=true;}catch(...){}
     if (currentFrame >= cmdBufs.size() || cmdBufs[currentFrame] == VK_NULL_HANDLE) return;
     bool currentFenceWaited = false;
     if (!vk_.GetFenceStatus || vk_.GetFenceStatus(device, inFlightFences[currentFrame]) == VK_NOT_READY) {
-        vk_.WaitForFences(device,1,&inFlightFences[currentFrame],VK_TRUE,UINT64_MAX);
+        if (vk_.WaitForFences(device,1,&inFlightFences[currentFrame],VK_TRUE,2000000000ULL) != VK_SUCCESS) {
+            RLOG_E("renderFrame: current-frame fence wait timed out (2s), skipping frame");
+            return;
+        }
         currentFenceWaited = true;
     }
 
     uint32_t imgIdx;
-    VkResult res=vk_.AcquireNextImageKHR(device,swapchain,UINT64_MAX,imgAvailSems[currentFrame],VK_NULL_HANDLE,&imgIdx);
+    // ERL bug report #9: real timeout so VK_TIMEOUT is reachable; existing non-success guard below returns on it.
+    VkResult res=vk_.AcquireNextImageKHR(device,swapchain,2000000000ULL,imgAvailSems[currentFrame],VK_NULL_HANDLE,&imgIdx);
     if (res==VK_ERROR_OUT_OF_DATE_KHR||res==VK_ERROR_SURFACE_LOST_KHR){fbResized.store(true);return;}
     if (res!=VK_SUCCESS&&res!=VK_SUBOPTIMAL_KHR) return;
     if (imgIdx >= swapchainFBs.size() || imgIdx >= swapchainImages.size()) {
@@ -1530,7 +1549,10 @@ ok=true;}catch(...){}
     if (imgInFlight[imgIdx]!=VK_NULL_HANDLE &&
         (!currentFenceWaited || imgInFlight[imgIdx] != inFlightFences[currentFrame])) {
         if (!vk_.GetFenceStatus || vk_.GetFenceStatus(device, imgInFlight[imgIdx]) == VK_NOT_READY) {
-            vk_.WaitForFences(device,1,&imgInFlight[imgIdx],VK_TRUE,UINT64_MAX);
+            if (vk_.WaitForFences(device,1,&imgInFlight[imgIdx],VK_TRUE,2000000000ULL) != VK_SUCCESS) {
+                RLOG_E("renderFrame: in-flight image fence wait timed out (2s), skipping frame");
+                return;
+            }
         }
     }
     imgInFlight[imgIdx]=inFlightFences[currentFrame];
@@ -1750,6 +1772,27 @@ void VulkanRendererContext::updateWindowContentAHB(int64_t id, AHardwareBuffer* 
         cit = ahbImportCache.find(ahb);
         RLOG("updateWindowContentAHB: imported new AHB %p for id=%" PRId64 " (%dx%d)",
             (void*)ahb, id, tmp.w, tmp.h);
+
+        // ERL bug report #9: a window that receives many distinct AHB pointers over its
+        // lifetime (rather than cycling a small fixed swapchain pool) otherwise accumulates
+        // one VkImage+VkDeviceMemory+descriptor set per import forever. Cap at 4 tracked
+        // per window; evict the oldest via the existing deleteQueue deferred-destruction path
+        // (same one used for whole-window teardown, drained under renderMutex each frame).
+        // The just-imported AHB is newest (at back) so it is never the one evicted, keeping cit valid.
+        auto& list = windowAhbs[id];
+        constexpr size_t kMaxTrackedPerWindow = 4;
+        while (list.size() > kMaxTrackedPerWindow) {
+            AHardwareBuffer* stale = list.front();
+            list.erase(list.begin());
+            auto sit = ahbImportCache.find(stale);
+            if (sit != ahbImportCache.end()) {
+                WinTex deferred = sit->second;
+                deferred.isAHB = false;
+                deleteQueue.push_back(deferred);
+                AHardwareBuffer_release(stale);
+                ahbImportCache.erase(sit);
+            }
+        }
     }
 
 

--- a/app/src/main/cpp/winlator/drawablepool.c
+++ b/app/src/main/cpp/winlator/drawablepool.c
@@ -1,0 +1,38 @@
+// ERL bug report #2: own tiny library (libdrawablepool.so) — deliberately
+// dependency-free (just libc + JNI) so it can be built and shipped independent
+// of the main winlator native codebase. Backs the X-server Drawable buffer pool
+// with native-heap calloc/free, bypassing ART's small non-moving space.
+#include <jni.h>
+#include <stdlib.h>
+#include <string.h>
+
+JNIEXPORT jobject JNICALL
+Java_com_winlator_star_xserver_DrawableBufferPool_nativeAlloc(JNIEnv *env, jclass clazz, jint capacity) {
+    (void) clazz;
+    if (capacity <= 0) return NULL;
+    void *mem = calloc(1, (size_t) capacity);
+    if (mem == NULL) return NULL;
+    jobject buffer = (*env)->NewDirectByteBuffer(env, mem, capacity);
+    if (buffer == NULL) { free(mem); return NULL; }
+    return buffer;
+}
+
+JNIEXPORT void JNICALL
+Java_com_winlator_star_xserver_DrawableBufferPool_nativeFree(JNIEnv *env, jclass clazz, jobject buffer) {
+    (void) clazz;
+    if (buffer == NULL) return;
+    void *mem = (*env)->GetDirectBufferAddress(env, buffer);
+    if (mem != NULL) free(mem);
+}
+
+// Zero a pooled buffer being handed back out by obtain(), in place, via its own
+// native address — avoids allocating a fresh (often multi-MB) Java array on every
+// pool hit just to memcpy it in through JNI's GetByteArrayRegion, which was both
+// wasteful and, in one build, the exact SIGSEGV crash frame in a captured tombstone.
+JNIEXPORT void JNICALL
+Java_com_winlator_star_xserver_DrawableBufferPool_nativeZero(JNIEnv *env, jclass clazz, jobject buffer, jint capacity) {
+    (void) clazz;
+    if (buffer == NULL || capacity <= 0) return;
+    void *mem = (*env)->GetDirectBufferAddress(env, buffer);
+    if (mem != NULL) memset(mem, 0, (size_t) capacity);
+}

--- a/app/src/main/cpp/winlator/gpu_image.c
+++ b/app/src/main/cpp/winlator/gpu_image.c
@@ -159,6 +159,16 @@ Java_com_winlator_star_renderer_GPUImage_lockHardwareBuffer(JNIEnv *env, jobject
     jmethodID setStride = (*env)->GetMethodID(env, cls, "setStride", "(S)V");
     if (setStride)
         (*env)->CallVoidMethod(env, obj, setStride, (jshort)desc.stride);
+    // ERL bug report #6: forward the buffer's REAL width/height (already in desc,
+    // same struct) so DRI3 can stop trusting the wire-protocol height, which for
+    // some titles (HoMM V: Hammer of Fate) doesn't match the buffer and produced a
+    // garbage swapchain size -> system-wide OOM kill.
+    jmethodID setWidth = (*env)->GetMethodID(env, cls, "setWidth", "(S)V");
+    if (setWidth)
+        (*env)->CallVoidMethod(env, obj, setWidth, (jshort)desc.width);
+    jmethodID setHeight = (*env)->GetMethodID(env, cls, "setHeight", "(S)V");
+    if (setHeight)
+        (*env)->CallVoidMethod(env, obj, setHeight, (jshort)desc.height);
 
     jobject buffer = (*env)->NewDirectByteBuffer(env, addr, (jlong)desc.stride * desc.height * 4);
     if (!buffer) {

--- a/app/src/main/java/com/winlator/star/renderer/ASurfaceRenderer.java
+++ b/app/src/main/java/com/winlator/star/renderer/ASurfaceRenderer.java
@@ -443,9 +443,10 @@ public class ASurfaceRenderer implements HostRenderer,
         if (!surfaceInitialized || !cursorVisible) return;
         if (cursor != null && !cursor.isVisible()) return;
         Drawable cd = cursor != null ? cursor.cursorImage : null;
-        if (cd == null || cd.getBuffer() == null) return;
+        if (cd == null) return;
         synchronized (cd.renderLock) {
             ByteBuffer buf = cd.getBuffer();
+            if (buf == null) return;
             nativeScanoutSetCursorImage(buf, cd.width, cd.height, (short) (buf.capacity() / (cd.height * 4)));
         }
     }

--- a/app/src/main/java/com/winlator/star/renderer/GLRenderer.java
+++ b/app/src/main/java/com/winlator/star/renderer/GLRenderer.java
@@ -705,9 +705,10 @@ public class GLRenderer implements GLSurfaceView.Renderer, WindowManager.OnWindo
         } else {
             cd = rootCursorDrawable;
         }
-        if (cd != null && cd.getBuffer() != null) {
+        if (cd != null) {
             synchronized (cd.renderLock) {
                 ByteBuffer buf = cd.getBuffer();
+                if (buf == null) return;
                 short stride = (short) (buf.capacity() / (cd.height * 4));
                 scanout.setCursorImage(buf, cd.width, cd.height, stride);
             }

--- a/app/src/main/java/com/winlator/star/renderer/GPUImage.java
+++ b/app/src/main/java/com/winlator/star/renderer/GPUImage.java
@@ -9,6 +9,8 @@ public class GPUImage extends NativeTexture {
     private long imageKHRPtr;
     private ByteBuffer virtualData;
     private short stride;
+    private short width;
+    private short height;
     private static boolean supported = false;
 
     static {
@@ -69,6 +71,18 @@ public class GPUImage extends NativeTexture {
     private void setStride(short stride) {
         this.stride = stride;
     }
+
+    // ERL bug report #6: real buffer dimensions from AHardwareBuffer_describe.
+    // @Keep because gpu_image.c resolves these by name via GetMethodID.
+    public short getWidth() { return width; }
+
+    public short getHeight() { return height; }
+
+    @Keep
+    private void setWidth(short width) { this.width = width; }
+
+    @Keep
+    private void setHeight(short height) { this.height = height; }
 
     @Override
     public ByteBuffer getVirtualData() {

--- a/app/src/main/java/com/winlator/star/renderer/vulkan/VulkanRenderer.java
+++ b/app/src/main/java/com/winlator/star/renderer/vulkan/VulkanRenderer.java
@@ -455,13 +455,15 @@ public class VulkanRenderer implements WindowManager.OnWindowModificationListene
             cd = cursor.cursorImage; hotX = (short)cursor.hotSpotX; hotY = (short)cursor.hotSpotY;
         } else { cd = rootCursorDrawable; }
         nativeSetCursorVisible(nativeHandle, effVis);
-        if (effVis && cd != null && cd.getBuffer() != null) {
+        if (effVis && cd != null) {
             synchronized (cd.renderLock) {
-                nativeUpdateCursorImage(nativeHandle, cd.getBuffer(), cd.width, cd.height, hotX, hotY);
+                java.nio.ByteBuffer buf = cd.getBuffer();
+                if (buf == null) return;
+                nativeUpdateCursorImage(nativeHandle, buf, cd.width, cd.height, hotX, hotY);
                 if (nativeMode) {
-                    java.nio.ByteBuffer buf = cd.getBuffer();
-                    short stride = (short)(buf.capacity() / (cd.height * 4));
-                    nativeScanoutSetCursorImage(nativeHandle, buf, cd.width, cd.height, stride);
+                    java.nio.ByteBuffer buf2 = cd.getBuffer();
+                    short stride = (short)(buf2.capacity() / (cd.height * 4));
+                    nativeScanoutSetCursorImage(nativeHandle, buf2, cd.width, cd.height, stride);
                 }
             }
         }

--- a/app/src/main/java/com/winlator/star/xserver/Colormap.java
+++ b/app/src/main/java/com/winlator/star/xserver/Colormap.java
@@ -1,0 +1,16 @@
+package com.winlator.star.xserver;
+
+// ERL bug report #7: colormaps had no representation at all — Create/Free were no-ops
+// and GetWindowAttributes always reported None. Visuals here are TrueColor-only, so this
+// is pure id/lifecycle bookkeeping (no real color-index allocation), just enough for
+// Create/Free/GetWindowAttributes to agree so Mesa stops warning "Window has no colormap!".
+public class Colormap extends XResource {
+    public final int window;
+    public final int visual;
+
+    public Colormap(int id, int window, int visual) {
+        super(id);
+        this.window = window;
+        this.visual = visual;
+    }
+}

--- a/app/src/main/java/com/winlator/star/xserver/ColormapManager.java
+++ b/app/src/main/java/com/winlator/star/xserver/ColormapManager.java
@@ -1,0 +1,29 @@
+package com.winlator.star.xserver;
+
+import android.util.SparseArray;
+
+// ERL bug report #7. Mirrors PixmapManager: tracks Colormap resources so Create/Free and
+// per-client cleanup on disconnect work like every other resource type.
+public class ColormapManager extends XResourceManager {
+    private final SparseArray<Colormap> colormaps = new SparseArray<>();
+
+    public Colormap createColormap(int id, int window, int visual) {
+        if (colormaps.indexOfKey(id) >= 0) return null;
+        Colormap colormap = new Colormap(id, window, visual);
+        colormaps.put(id, colormap);
+        triggerOnCreateResourceListener(colormap);
+        return colormap;
+    }
+
+    public void freeColormap(int id) {
+        Colormap colormap = colormaps.get(id);
+        if (colormap != null) {
+            triggerOnFreeResourceListener(colormap);
+            colormaps.remove(id);
+        }
+    }
+
+    public Colormap getColormap(int id) {
+        return colormaps.get(id);
+    }
+}

--- a/app/src/main/java/com/winlator/star/xserver/CursorManager.java
+++ b/app/src/main/java/com/winlator/star/xserver/CursorManager.java
@@ -18,7 +18,7 @@ public class CursorManager extends XResourceManager {
 
     public Cursor createCursor(int id, short x, short y, Pixmap sourcePixmap, Pixmap maskPixmap) {
         if (cursors.indexOfKey(id) >= 0) return null;
-        Drawable drawable = drawableManager.createDrawable(0, sourcePixmap.drawable.width, sourcePixmap.drawable.height, sourcePixmap.drawable.visual);
+        Drawable drawable = drawableManager.createDrawable(IDGenerator.generate(), sourcePixmap.drawable.width, sourcePixmap.drawable.height, sourcePixmap.drawable.visual);
         Cursor cursor = new Cursor(id, x, y, drawable, sourcePixmap.drawable, maskPixmap != null ? maskPixmap.drawable : null);
         cursors.put(id, cursor);
         triggerOnCreateResourceListener(cursor);
@@ -26,7 +26,11 @@ public class CursorManager extends XResourceManager {
     }
 
     public void freeCursor(int id) {
-        triggerOnFreeResourceListener(cursors.get(id));
+        Cursor cursor = cursors.get(id);
+        if (cursor != null && cursor.cursorImage != null) {
+            drawableManager.removeDrawable(cursor.cursorImage.id);
+        }
+        triggerOnFreeResourceListener(cursor);
         cursors.remove(id);
     }
 

--- a/app/src/main/java/com/winlator/star/xserver/Drawable.java
+++ b/app/src/main/java/com/winlator/star/xserver/Drawable.java
@@ -53,10 +53,28 @@ public class Drawable extends XResource {
             }
         }
         if (this.data == null) {
-            this.data = ByteBuffer.allocateDirect(width * height * 4).order(ByteOrder.LITTLE_ENDIAN);
+            this.data = DrawableBufferPool.obtain(width * height * 4);
         }
         if (this.data == null) {
             throw new IllegalStateException("Drawable.data initialized as null!");
+        }
+    }
+
+    // ERL bug report #3/#4: null-check must happen INSIDE renderLock — two concurrent
+    // removeDrawable() calls (direct + onFreeResource listener path) could otherwise both
+    // observe non-null data and both release the same buffer into two pool slots.
+    // The NativeTexture guard is issue #4: once data has been repointed at a NativeTexture's
+    // (GPUImage/AHBImage) AHardwareBuffer memory, it was never pool-allocated — releasing it
+    // to the pool hands live hardware-buffer memory back out of obtain() for something
+    // unrelated (the "10000x10000"/instant-crash pattern on several D3D9 titles).
+    public void releaseBuffer() {
+        synchronized (renderLock) {
+            if (data != null) {
+                if (!DRAWABLE_FOR_ASR && !(texture instanceof NativeTexture)) {
+                    DrawableBufferPool.release(data);
+                }
+                data = null;
+            }
         }
     }
 

--- a/app/src/main/java/com/winlator/star/xserver/Drawable.java
+++ b/app/src/main/java/com/winlator/star/xserver/Drawable.java
@@ -91,7 +91,19 @@ public class Drawable extends XResource {
     public void setTexture(Texture texture) {
         if (texture instanceof NativeTexture) {
             ByteBuffer vd = ((NativeTexture)texture).getVirtualData();
-            if (vd != null) data = vd;
+            if (vd != null) {
+                // ERL bug report #8: on the FIRST transition from a pool-owned buffer to a
+                // NativeTexture's virtual data, release the old pool buffer instead of orphaning
+                // it. The guard fires only when data is genuinely still pool-owned (not ASR, and
+                // this.texture not already a NativeTexture) — otherwise we'd pool-release
+                // hardware-buffer memory (the issue #4 bug in reverse).
+                synchronized (renderLock) {
+                    if (data != null && !DRAWABLE_FOR_ASR && !(this.texture instanceof NativeTexture)) {
+                        DrawableBufferPool.release(data);
+                    }
+                    data = vd;
+                }
+            }
         }
         this.texture = texture;
     }

--- a/app/src/main/java/com/winlator/star/xserver/DrawableBufferPool.java
+++ b/app/src/main/java/com/winlator/star/xserver/DrawableBufferPool.java
@@ -1,0 +1,43 @@
+package com.winlator.star.xserver;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+// ERL bug report #2: Drawable buffers were allocated via ByteBuffer.allocateDirect,
+// which lands in ART's non-moving space — a small (~57MB on some devices), non-compacting
+// region. Cursor/drawable churn fragments it until allocation fails, independent of leaks.
+// This pool backs those buffers with calloc/free in the native heap (libdrawablepool.so),
+// bypassing ART's heap entirely, and reuses freed buffers of matching capacity.
+public class DrawableBufferPool {
+    static {
+        System.loadLibrary("drawablepool");
+    }
+
+    private static native ByteBuffer nativeAlloc(int capacity);
+    private static native void nativeFree(ByteBuffer buffer);
+    private static native void nativeZero(ByteBuffer buffer, int capacity);
+
+    private static final AtomicReferenceArray<ByteBuffer> pool = new AtomicReferenceArray<>(64);
+
+    public static ByteBuffer obtain(int capacity) {
+        for (int i = 0; i < pool.length(); i++) {
+            ByteBuffer buffer = pool.get(i);
+            if (buffer != null && buffer.capacity() == capacity && pool.compareAndSet(i, buffer, null)) {
+                buffer.clear();
+                nativeZero(buffer, capacity);
+                return buffer;
+            }
+        }
+        ByteBuffer fresh = nativeAlloc(capacity);
+        if (fresh == null) throw new OutOfMemoryError("DrawableBufferPool: native allocation failed for " + capacity + " bytes");
+        return fresh.order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    public static void release(ByteBuffer buffer) {
+        for (int i = 0; i < pool.length(); i++) {
+            if (pool.compareAndSet(i, null, buffer)) return;
+        }
+        nativeFree(buffer);
+    }
+}

--- a/app/src/main/java/com/winlator/star/xserver/DrawableManager.java
+++ b/app/src/main/java/com/winlator/star/xserver/DrawableManager.java
@@ -56,6 +56,7 @@ public class DrawableManager extends XResourceManager implements XResourceManage
         if (onDestroyListener != null) onDestroyListener.call(drawable);
 
         drawable.setOnDrawListener(null);
+        drawable.releaseBuffer();
         drawables.remove(id);
     }
 

--- a/app/src/main/java/com/winlator/star/xserver/WindowAttributes.java
+++ b/app/src/main/java/com/winlator/star/xserver/WindowAttributes.java
@@ -27,6 +27,7 @@ public class WindowAttributes {
     private BackingStore backingStore = BackingStore.NOT_USEFUL;
     private BitGravity bitGravity = BitGravity.CENTER;
     private Cursor cursor;
+    private Colormap colormap;
     private Bitmask doNotPropagateMask = new Bitmask(0);
     private Bitmask eventMask = new Bitmask(0);
     private boolean mapped = false;
@@ -55,6 +56,10 @@ public class WindowAttributes {
 
     public BitGravity getBitGravity() {
         return bitGravity;
+    }
+
+    public Colormap getColormap() {
+        return colormap;
     }
 
     public Cursor getCursor() {
@@ -146,10 +151,14 @@ public class WindowAttributes {
                 case FLAG_CURSOR:
                     cursor = client.xServer.cursorManager.getCursor(inputStream.readInt());
                     break;
+                case FLAG_COLORMAP:
+                    // ERL bug report #7: actually store the colormap so GetWindowAttributes
+                    // can report it, instead of skipping it and always returning None.
+                    colormap = client.xServer.colormapManager.getColormap(inputStream.readInt());
+                    break;
                 case FLAG_BACKGROUND_PIXMAP:
                 case FLAG_BORDER_PIXMAP:
                 case FLAG_BORDER_PIXEL:
-                case FLAG_COLORMAP:
                     inputStream.skip(4);
                     break;
             }

--- a/app/src/main/java/com/winlator/star/xserver/XClient.java
+++ b/app/src/main/java/com/winlator/star/xserver/XClient.java
@@ -33,6 +33,7 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
             xServer.pixmapManager.addOnResourceLifecycleListener(this);
             xServer.graphicsContextManager.addOnResourceLifecycleListener(this);
             xServer.cursorManager.addOnResourceLifecycleListener(this);
+            xServer.colormapManager.addOnResourceLifecycleListener(this);
         }
     }
 
@@ -87,6 +88,9 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
                 else if (resource instanceof Cursor) {
                     xServer.cursorManager.freeCursor(resource.id);
                 }
+                else if (resource instanceof Colormap) {
+                    xServer.colormapManager.freeColormap(resource.id);
+                }
             }
 
             while (!eventListeners.isEmpty()) {
@@ -98,6 +102,7 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
             xServer.pixmapManager.removeOnResourceLifecycleListener(this);
             xServer.graphicsContextManager.removeOnResourceLifecycleListener(this);
             xServer.cursorManager.removeOnResourceLifecycleListener(this);
+            xServer.colormapManager.removeOnResourceLifecycleListener(this);
             xServer.resourceIDs.free(resourceIDBase);
         }
     }

--- a/app/src/main/java/com/winlator/star/xserver/XClientRequestHandler.java
+++ b/app/src/main/java/com/winlator/star/xserver/XClientRequestHandler.java
@@ -10,6 +10,7 @@ import com.winlator.star.xconnector.XStreamLock;
 import com.winlator.star.xserver.errors.XRequestError;
 import com.winlator.star.xserver.extensions.Extension;
 import com.winlator.star.xserver.requests.AtomRequests;
+import com.winlator.star.xserver.requests.ColormapRequests;
 import com.winlator.star.xserver.requests.CursorRequests;
 import com.winlator.star.xserver.requests.DrawRequests;
 import com.winlator.star.xserver.requests.ExtensionRequests;
@@ -383,10 +384,10 @@ public class XClientRequestHandler implements RequestHandler {
                     }
                     break;
                 case ClientOpcodes.CREATE_COLORMAP:
-                    client.skipRequest();
+                    ColormapRequests.createColormap(client, inputStream, outputStream);
                     break;
                 case ClientOpcodes.FREE_COLORMAP:
-                    client.skipRequest();
+                    ColormapRequests.freeColormap(client, inputStream, outputStream);
                     break;
                 case ClientOpcodes.CREATE_CURSOR:
                     try (XLock lock = client.xServer.lock(XServer.Lockable.PIXMAP_MANAGER, XServer.Lockable.DRAWABLE_MANAGER, XServer.Lockable.CURSOR_MANAGER)) {

--- a/app/src/main/java/com/winlator/star/xserver/XServer.java
+++ b/app/src/main/java/com/winlator/star/xserver/XServer.java
@@ -25,6 +25,7 @@ public class XServer {
     public final SparseArray<Extension> extensions = new SparseArray<>();
     public final ScreenInfo screenInfo;
     public final PixmapManager pixmapManager;
+    public final ColormapManager colormapManager = new ColormapManager();
     public final ResourceIDs resourceIDs = new ResourceIDs(128);
     public final GraphicsContextManager graphicsContextManager = new GraphicsContextManager();
     public final SelectionManager selectionManager;

--- a/app/src/main/java/com/winlator/star/xserver/extensions/DRI3Extension.java
+++ b/app/src/main/java/com/winlator/star/xserver/extensions/DRI3Extension.java
@@ -157,7 +157,9 @@ public class DRI3Extension implements Extension {
             // GPUImage(fd) now locks the buffer, so getStride() is valid (matches the SHM path's
             // stride-based width). Mark the drawable directScanout so the Vulkan renderer can
             // present the AHB directly instead of compositing a blank CPU buffer (-> black).
-            Drawable drawable = client.xServer.drawableManager.createDrawable(pixmapId, gpuImage.getStride(), height, depth);
+            // ERL bug report #6: use the buffer's real height (from AHardwareBuffer_describe),
+            // mirroring how width already uses getStride() rather than the wire value.
+            Drawable drawable = client.xServer.drawableManager.createDrawable(pixmapId, gpuImage.getStride(), gpuImage.getHeight(), depth);
             drawable.setTexture(gpuImage);
             drawable.setDirectScanout(true);
             client.xServer.pixmapManager.createPixmap(drawable);

--- a/app/src/main/java/com/winlator/star/xserver/requests/ColormapRequests.java
+++ b/app/src/main/java/com/winlator/star/xserver/requests/ColormapRequests.java
@@ -1,0 +1,24 @@
+package com.winlator.star.xserver.requests;
+
+import com.winlator.star.xserver.Colormap;
+import com.winlator.star.xserver.XClient;
+import com.winlator.star.xconnector.XInputStream;
+import com.winlator.star.xconnector.XOutputStream;
+
+// ERL bug report #7. Extracted into its own class (rather than inlined into
+// XClientRequestHandler's switch dispatcher) deliberately — inlining new logic into that
+// giant switch risks a dex-verifier register-type conflict that only surfaces as a
+// VerifyError at class-load on a real device, passing a normal build step silently.
+public class ColormapRequests {
+    public static void createColormap(XClient client, XInputStream inputStream, XOutputStream outputStream) {
+        int mid = inputStream.readInt();
+        int window = inputStream.readInt();
+        int visual = inputStream.readInt();
+        Colormap colormap = client.xServer.colormapManager.createColormap(mid, window, visual);
+        if (colormap != null) client.registerAsOwnerOfResource(colormap);
+    }
+
+    public static void freeColormap(XClient client, XInputStream inputStream, XOutputStream outputStream) {
+        client.xServer.colormapManager.freeColormap(inputStream.readInt());
+    }
+}

--- a/app/src/main/java/com/winlator/star/xserver/requests/WindowRequests.java
+++ b/app/src/main/java/com/winlator/star/xserver/requests/WindowRequests.java
@@ -7,6 +7,7 @@ import com.winlator.star.xconnector.XOutputStream;
 import com.winlator.star.xconnector.XStreamLock;
 import com.winlator.star.xserver.Drawable;
 import com.winlator.star.xserver.Bitmask;
+import com.winlator.star.xserver.Colormap;
 import com.winlator.star.xserver.WindowAttributes;
 import com.winlator.star.xserver.errors.BadDrawable;
 import com.winlator.star.xserver.errors.BadIdChoice;
@@ -75,7 +76,10 @@ public abstract class WindowRequests {
             outputStream.writeByte((byte)1);
             outputStream.writeByte((byte)window.getMapState().ordinal());
             outputStream.writeByte((byte)(window.attributes.isOverrideRedirect() ? 1 : 0));
-            outputStream.writeInt(0);
+            // ERL bug report #7: report the window's real colormap (this is the field Mesa
+            // reads) instead of hardcoding None, which caused "Window has no colormap!".
+            Colormap colormap = window.attributes.getColormap();
+            outputStream.writeInt(colormap != null ? colormap.id : 0);
             outputStream.writeInt(window.getAllEventMasks().getBits());
             outputStream.writeInt(client.getEventMaskForWindow(window).getBits());
             outputStream.writeShort((short)window.attributes.getDoNotPropagateMask().getBits());


### PR DESCRIPTION
## Summary

Fixes a chain of crashes, memory leaks, and hangs in the X server / renderer, **found and fixed on-device (Adreno 650 / Turnip) by contributor ERL**, who sent a detailed write-up and diffs across versions 2.9.4 → 2.9.7. Ported here against `main`, one logical commit per issue, all crediting ERL.

CI (build-artifacts) is green on all three flavors; three native libs were rebuilt (`libwinlator`, `libvulkan_renderer`, and a new `libdrawablepool`).

## Fixes

| # | Fix |
|---|-----|
| 1 | **Cursor Drawable leak → native OOM ~10-15 min** (e.g. Settlers II). Cursor content Drawable was created with a hardcoded `id=0`, so it was never tracked in `DrawableManager` and `freeCursor()` never removed it. Now uses a real `IDGenerator.generate()` id and removes it on free. |
| 2 | **ART non-moving-space fragmentation.** New `DrawableBufferPool` backs Drawable buffers with native-heap `calloc`/`free` (new `libdrawablepool.so`) instead of `ByteBuffer.allocateDirect`, bypassing ART's small non-compacting region that fragments under churn. |
| 3 | **Double-release race** in `Drawable.releaseBuffer()` — null-check moved inside `renderLock`. |
| 4 | **NativeTexture type confusion** — `releaseBuffer()` was pool-releasing AHardwareBuffer memory it never allocated (root cause of the "10000x10000"/instant-crash pattern on several D3D9 titles). Now skipped when `data` points at a `NativeTexture`. |
| 5 | **Same check-then-lock cursor-scanout race** independently present in `GLRenderer`, `ASurfaceRenderer`, and `VulkanRenderer` — re-check for null inside the lock. |
| 6 | **`GPUImage` real width/height** — DRI3 trusted the wire-protocol height instead of the buffer's real height, producing a bogus swapchain size / system-wide OOM kill (Heroes of Might and Magic V: Hammer of Fate). `gpu_image.c` now forwards `desc.width`/`desc.height`; DRI3 uses `getHeight()` (mirroring how width already uses `getStride()`). |
| 7 | **Colormap tracking** — `CREATE`/`FREE_COLORMAP` were no-ops and `GetWindowAttributes` hardcoded `None`, causing `Mesa: Window has no colormap!` and a black-screen hang on the wined3d+GL path. New `Colormap`/`ColormapManager`/`ColormapRequests` wired through the X server (TrueColor-only, pure id/lifecycle bookkeeping). |
| 8 | **`setTexture()` orphaned the old pool buffer** on a Drawable's first hardware-texture transition — now released back to the pool, under lock, guarded to fire only on the genuine first transition. |
| 9 | **`VulkanRendererContext`: five unbounded `WaitForFences(UINT64_MAX)`** → a never-signalling fence hung the render thread forever. Now 2s timeout + safe bail (resize path never destroys in-flight swapchain resources on timeout). Plus **unbounded per-window AHB import growth** capped at 4, evicted via the existing `deleteQueue`. |

## Still open (not fixed here)

**#10 — Heroes of Might and Magic V: Hammer of Fate black-screen hang**, Bannerlator-specific (does not reproduce on other forks with identical Turnip/DXVK/Proton-9.0-arm64ec-0). ERL traced it to a `winhandler.exe` process-enumeration loop (`NtQueryInformationProcess` on repeated handles); the next lead is the `WinHandler.java`↔`winhandler.c` UDP dispatch (ports 7946/7947) potentially spinning on a reply that never arrives. Flagged for whoever knows `winhandler.c` best. The #9 fixes were verified **not** to be the cause.

## Testing

- CI: all three flavors build; native rebuilds compile clean.
- ERL verified all fixes on-device (Adreno 650 / Turnip).
- Recommend a device pass before merge on the two broadest-reach changes — **#6** (affects all DRI3 hardware-buffer D3D titles) and **#2** (affects all Drawable allocation) — ideally including a non-Adreno (Mali) device, which ERL could not cover.

## Credit

All fixes reported and originally implemented by **ERL**. No API/ABI, container/prefix, or Wine/Proton asset changes — everything is within the app's own X server and renderer.
